### PR TITLE
adding index `us_radacct_id` on table `user_stats`

### DIFF
--- a/cake4/rd_cake/setup/db/rd.sql
+++ b/cake4/rd_cake/setup/db/rd.sql
@@ -5073,7 +5073,8 @@ CREATE TABLE `user_stats` (
   KEY `us_realm_timestamp` (`realm`,`timestamp`),
   KEY `us_username_timestamp` (`username`,`timestamp`),
   KEY `us_nasidentifier_timestamp` (`nasidentifier`,`timestamp`),
-  KEY `us_callingstationid_timestamp` (`callingstationid`,`timestamp`)
+  KEY `us_callingstationid_timestamp` (`callingstationid`,`timestamp`),
+  KEY `us_radacct_id` (`radacct_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
adding index `us_radacct_id` for join between `user_stats` and `radacct` tables

I am using radius-desk for VPN accounting.
There is a slow select query with a join between `user_stats` and `radacct` that is saw in "slow query log". This query is going to even more slower even these tables are larger.

This index will highly help the performance on large data on `user_stats` and `radacct` tables.