### PR TITLE
Update local_build.sh

### DIFF
--- a/docker/local_build.sh
+++ b/docker/local_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker network create --attachable -d bridge radiusdesk-bridge
+docker network create --attachable -d bridge "${RADIUSDESK_NETWORK}"
 
 source ./.env
 

--- a/docker/local_build.sh
+++ b/docker/local_build.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-set -xu
-
-docker network create --attachable -d bridge radiusdesk-bridge || exit 1
+docker network create --attachable -d bridge radiusdesk-bridge
 
 source ./.env
 
@@ -17,42 +15,41 @@ echo
 echo Starting Build ....
 echo
 echo Copying database files to volume mounts for MariaDB ...
-mkdir  -p /mnt/data/radiusdesk || exit 1
-mkdir  -p /mnt/data/radiusdesk/db_startup || exit 1
-mkdir  -p /mnt/data/radiusdesk/db_conf || exit 1
-chmod -R 777 /mnt/data/radiusdesk || exit 1
-chmod -R 777 /mnt/data/radiusdesk/db_startup || exit 1
-chmod -R 777 /mnt/data/radiusdesk/db_conf || exit 1
+mkdir  -p "${RADIUSDESK_VOLUME}"
+mkdir  -p "${RADIUSDESK_VOLUME}/db_startup"
+mkdir  -p "${RADIUSDESK_VOLUME}/db_conf"
+chmod -R 777 "${RADIUSDESK_VOLUME}"
+chmod -R 777 "${RADIUSDESK_VOLUME}/db_startup"
+chmod -R 777 "${RADIUSDESK_VOLUME}/db_conf"
 
 if [ -d "rdcore" ]
 then
     echo "Directory rdcore exists."
 else
-    git clone https://github.com/RADIUSdesk/rdcore || exit 1
+    git clone https://github.com/RADIUSdesk/rdcore
 fi
 
-cp rdcore/cake4/rd_cake/setup/db/rd.sql $RADIUSDESK_VOLUME/db_startup || exit 1
-cp db_priveleges.sql $RADIUSDESK_VOLUME/db_startup || exit 1
-cp startup.sh $RADIUSDESK_VOLUME/db_startup || exit 1
-cp my_custom.cnf $RADIUSDESK_VOLUME/db_conf || exit 1
+cp rdcore/cake4/rd_cake/setup/db/rd.sql "${RADIUSDESK_VOLUME}/db_startup"
+cp db_priveleges.sql "$RADIUSDESK_VOLUME/db_startup"
+cp startup.sh "$RADIUSDESK_VOLUME/db_startup"
+cp my_custom.cnf "$RADIUSDESK_VOLUME/db_conf"
 
 echo
 echo Building docker database container ...
 #docker-compose config
-docker compose up -d rdmariadb || exit 1
-
+docker compose up -d rdmariadb
 echo
 echo Waiting for MariaDB to come up ...
 sleep 60
 
 echo Creating database for Radiusdesk ...
 # Build daatabase
-docker exec -u 0 -it radiusdesk-mariadb /tmp/startup.sh || exit 1
+docker exec -u 0 -it radiusdesk-mariadb /tmp/startup.sh
 echo
 echo Building Radiusdesk container with nginx, php-fpm and freeradius ...
 
-docker compose build || exit 1
-docker compose up -d radiusdesk || exit 1
+docker compose build
+docker compose up -d radiusdesk
 
 echo
 echo All done!


### PR DESCRIPTION
Change the `mkdir` and `chmod` lines to include using the "${RADIUSDESK_VOLUME}" variable, since its used in the rest of the script, and because we're sourcing .env.

Also, there's beyond no need in having `|| exit 1` on every line that does something, especially if we have to run this more than once. Like, if we already have an nginx server running and port 80 is already in use.