### PR TITLE
Easier install of database patches for docker version

### DIFF
--- a/cake4/rd_cake/setup/db/8.110_add_mac_address_field.sql
+++ b/cake4/rd_cake/setup/db/8.110_add_mac_address_field.sql
@@ -15,7 +15,7 @@ begin
             ADD COLUMN mac_address VARCHAR(100) NOT NULL DEFAULT '',
             ADD INDEX idx_permanent_users_mac_address (mac_address);
             
-        CREATE INDEX idx_perm_users_expiry ON permanent_users (admin_state, to_date);
+        CREATE INDEX idx_perm_users_expiry ON permanent_users (admin_state, `to_date`);
     END IF;
 
 end//

--- a/docker/local_build.sh
+++ b/docker/local_build.sh
@@ -19,6 +19,7 @@ echo
 echo Copying database files to volume mounts for MariaDB ...
 mkdir  -p /mnt/data/radiusdesk || exit 1
 mkdir  -p /mnt/data/radiusdesk/db_startup || exit 1
+mkdir  -p /mnt/data/radiusdesk/db_startup/db_patches || exit 1
 mkdir  -p /mnt/data/radiusdesk/db_conf || exit 1
 chmod -R 777 /mnt/data/radiusdesk || exit 1
 chmod -R 777 /mnt/data/radiusdesk/db_startup || exit 1
@@ -32,6 +33,7 @@ else
 fi
 
 cp rdcore/cake4/rd_cake/setup/db/rd.sql $RADIUSDESK_VOLUME/db_startup || exit 1
+cp -r rdcore/cake4/rd_cake/setup/db/* $RADIUSDESK_VOLUME/db_startup/db_patches/ || exit 1
 cp db_priveleges.sql $RADIUSDESK_VOLUME/db_startup || exit 1
 cp startup.sh $RADIUSDESK_VOLUME/db_startup || exit 1
 cp my_custom.cnf $RADIUSDESK_VOLUME/db_conf || exit 1

--- a/docker/patch_db.sh
+++ b/docker/patch_db.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -xu
+
+source ./.env
+
+echo Radiusdesk DB Patcher
+echo ---------------------------------------
+echo
+
+cp rdcore/cake4/rd_cake/setup/db/* $RADIUSDESK_VOLUME/db_startup/db_patches
+cp startup.sh $RADIUSDESK_VOLUME/db_startup || exit 1
+
+echo Patching database for Radiusdesk ...
+docker exec -u 0 -it radiusdesk-mariadb /tmp/startup.sh || exit 1
+
+echo
+echo All done!

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -28,3 +28,24 @@ if [[ ! -f $FLAG ]]; then
    #echo COMPLETED DATABASE BUILD ...| tee /proc/1/fd/1 /var/log/init.log 
    echo COMPLETED DATABASE BUILD ...
 fi
+
+
+echo UPDATE PATCHED DATABASE TABLES
+
+#Apply all patches in numerical order, excluding rd.sql and rd.min.sql
+for patch in /tmp/db_patches/*.sql; do
+  filename=$(basename "$patch")
+
+  #Skip rd.sql and rd.min.sql
+  if [[ "$filename" == "rd.sql" || "$filename" == "rd.min.sql" ]]; then
+    echo "Skipping: $filename"
+    continue
+  fi
+
+  if [ -f "$patch" ]; then
+    echo "Applying patch: $filename"
+    mariadb -u root rd < "$patch"
+  fi
+done
+
+echo COMPLETED UPDATING PATCHED DATABASE TABLES ...


### PR DESCRIPTION
Added a patch_db.sh function to allow manual importing of SQL patches. 
Adapted initialization and startup scripts to install patches after the database has been initialized.